### PR TITLE
Prepare for Kubernetes

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 
 <body>
   <div id="app"></div>
+  <script src="/env.js"></script>
   <script type="module" src="/src/main.ts"></script>
 </body>
 

--- a/public/env.js
+++ b/public/env.js
@@ -1,0 +1,6 @@
+window.__ENV__ = {
+    VITE_USER_SERVICE_URL: "http://localhost:8500",
+    VITE_ROOM_SERVICE_URL: "http://localhost:8503",
+    VITE_ROOM_SERVICE_IMAGES_URL: "http://localhost:8505",
+    VITE_RESERVATION_SERVICE_URL: "http://localhost:8506"
+};

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -1,10 +1,13 @@
 import axios from "axios";
 
 export const axiosInstance = axios.create({
-    baseURL: "http://localhost:8500/api",
+    baseURL: (window.__ENV__?.VITE_USER_SERVICE_URL || "http://localhost:8500") + "/api",
 });
 axiosInstance.interceptors.request.use(
     config => {
+        console.log(window.__ENV__);
+        console.log(window.__ENV__?.VITE_USER_SERVICE_URL);
+
         const token = localStorage.getItem('jwt');
         if (token) {
             config.headers.Authorization = `Bearer ${token}`;
@@ -20,7 +23,7 @@ axiosInstance.interceptors.response.use(
 
 // TODO: Instead of two axios instances, create an API gateway.
 export const axiosInstanceRooms = axios.create({
-    baseURL: "http://localhost:8503/api",
+    baseURL: (window.__ENV__?.VITE_ROOM_SERVICE_URL || "http://localhost:8503") + "/api",
 });
 axiosInstanceRooms.interceptors.request.use(
     config => {
@@ -37,10 +40,15 @@ axiosInstanceRooms.interceptors.response.use(
     error => Promise.reject(error)
 );
 
+// No + "/api" for this one since this isn't an API server.
+export const RoomImageURL: string = (window.__ENV__?.VITE_ROOM_SERVICE_IMAGES_URL || "http://localhost:8505");
+
+
 // TODO: Instead of two axios instances, create an API gateway.
 export const axiosInstanceReservations = axios.create({
-    baseURL: "http://localhost:8506/api",
+    baseURL: (window.__ENV__?.VITE_RESERVATION_SERVICE_URL || "http://localhost:8506") + "/api",
 });
+
 axiosInstanceReservations.interceptors.request.use(
     config => {
         const token = localStorage.getItem('jwt');

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+    __ENV__?: Record<string, string>;
+}

--- a/src/views/room/RoomDetails.vue
+++ b/src/views/room/RoomDetails.vue
@@ -7,6 +7,7 @@ import RoomAvailabilityEditor from '../../components/room/RoomAvailabilityEditor
 import RoomPriceEditor from '../../components/room/RoomPriceEditor.vue';
 import { useAuthStore } from '../../stores/auth-store';
 import { UserRole } from '../../api/user.api';
+import { RoomImageURL } from '../../api/util';
 
 const route = useRoute();
 const router = useRouter();
@@ -82,11 +83,11 @@ const gotoReservation = () => {
                     <Galleria :value="room.photos" :responsiveOptions="galleryResponsiveOptions" :numVisible="5"
                         containerStyle="max-width: 80%; margin: auto;" class="preview-item">
                         <template #item="slotProps">
-                            <Image :src="`http://localhost:8505/img/${slotProps.item}`" preview
+                            <Image :src="`${RoomImageURL}/img/${slotProps.item}`" preview
                                 style="width: 300px; height: 300px; object-fit: cover;" />
                         </template>
                         <template #thumbnail="slotProps">
-                            <img :src="`http://localhost:8505/img/${slotProps.item}`"
+                            <img :src="`${RoomImageURL}/img/${slotProps.item}`"
                                 style="width: 100px; height: 100px; object-fit: cover;" />
                         </template>
                     </Galleria>

--- a/src/views/room/RoomsOfHost.vue
+++ b/src/views/room/RoomsOfHost.vue
@@ -4,6 +4,7 @@ import { useAuthStore } from '../../stores/auth-store';
 import { useRoute, useRouter } from 'vue-router';
 import { RoomAPI, type RoomDTO } from '../../api/room.api';
 import type { AxiosError, AxiosResponse } from 'axios';
+import { RoomImageURL } from '../../api/util';
 
 const router = useRouter();
 const route = useRoute();
@@ -45,7 +46,7 @@ onMounted(() => findByHostId());
                     <div class="flex-items">
                         <div class="preview-grid">
                             <div v-for="img in room.photos.slice(0, 4)" class="preview-item">
-                                <Image :src="`http://localhost:8505/img/${img}`"></Image>
+                                <Image :src="`${RoomImageURL}/img/${img}`"></Image>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Closes #19 

**Note:** The Kubernetes part (helm-charts repo) is _not_ important right now. That will be merged afterwards. The point of this series of PRs is to integrate these changes into a stable Docker image.

Part of:
- https://github.com/book-em/room-service/pull/17
- https://github.com/book-em/user-service/pull/24
- https://github.com/book-em/reservation-service/pull/6
- https://github.com/book-em/web-app/pull/20
- https://github.com/book-em/infrastructure/pull/14

This PR allows us to have dynamic env variables. `env.js` is intentionally put inside `public/` so it doesn't get minified, because Docker Compose and Kubernetes will both modify the contents of this file.

The reason we need this is because K8s and Compose have fundamentally different schemas for the URL. Those are defined inside the `infrastructure` repo for Compose and the `helm-charts` repo for Kubernetes.