### PR TITLE
Fix various

### DIFF
--- a/src/views/reservation/ReservationCreate.vue
+++ b/src/views/reservation/ReservationCreate.vue
@@ -151,7 +151,7 @@ const onGuestCountChange = (newValue: number) => {
             <FloatLabel class="mt-small">
                 <label for="fromDate">From</label>
                 <DatePicker id="fromDate" v-model="formDateFrom" v-on:value-change="onFromDateChanged"
-                    date-format="dd MM" showIcon class="w-full" />
+                    date-format="dd MM" showIcon class="w-full" :min-date="new Date()" />
             </FloatLabel>
 
             <FloatLabel class="mt-small">

--- a/src/views/reservation/ReservationCreate.vue
+++ b/src/views/reservation/ReservationCreate.vue
@@ -4,7 +4,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useAuthStore } from '../../stores/auth-store';
 import { ReservationAPI, ReservationRequestStatus, type CreateReservationRequestDTO, type ReservationRequestDTO } from '../../api/reservation.api';
 import type { AxiosError, AxiosResponse } from 'axios';
-import { type RoomAvailabilityListDTO, type RoomReservationQueryDTO, RoomAPI, type RoomReservationQueryResponseDTO } from '../../api/room.api';
+import { type RoomAvailabilityListDTO, type RoomReservationQueryDTO, RoomAPI, type RoomReservationQueryResponseDTO, type RoomDTO } from '../../api/room.api';
 import HeatmapCalendar from '../../components/HeatmapCalendar.vue';
 import { RefSymbol } from '@vue/reactivity';
 
@@ -12,6 +12,7 @@ const route = useRoute();
 const router = useRouter();
 const auth = useAuthStore();
 const roomId = ref(-1);
+const room = ref<RoomDTO | null>(null);
 const roomAvailability = ref<RoomAvailabilityListDTO | null>(null);
 const reservationQuery = ref<RoomReservationQueryResponseDTO | null>(null);
 
@@ -31,6 +32,13 @@ onMounted(() => {
     onFromDateChanged();
 
     queryReservationInfo();
+
+    RoomAPI.findById(roomId.value).then((res: AxiosResponse<RoomDTO>) => {
+        room.value = res.data;
+    }).catch((err: AxiosError) => {
+        error.value = 'Could not fetch room data. Check the console';
+        console.error(err);
+    });
 });
 onMounted(() => { formDateTo.value.setDate(formDateFrom.value.getDate() + 7); });
 
@@ -96,7 +104,7 @@ const onSubmitReservationRequest = () => {
     }).catch((err: AxiosError) => {
         console.log(err);
         if (err.status == 409) {
-            error.value = "You already have a reservation booked for this room";
+            error.value = "Cannot book reservation (clashing request or room is occupied right now)";
         } else if (err.status == 400) {
             error.value = "Invalid data, please make sure the room can be booked at this time";
         } else {
@@ -161,9 +169,13 @@ const onGuestCountChange = (newValue: number) => {
             </FloatLabel>
 
             <FloatLabel class="mt-small">
-                <InputNumber id="guestCount" v-model="formGuestCount" class="w-full" :min="1" :max="999" fluid
-                    @input="(e) => { onGuestCountChange(e.value as number); }" />
-                <label for="basePrice">Number of guests</label>
+                <InputNumber id="guestCount" v-model="formGuestCount" class="w-full" :min="room?.minGuests"
+                    :max="room?.maxGuests" fluid @input="(e) => { onGuestCountChange(e.value as number); }" />
+                <label for="basePrice">Number of guests
+                    <template v-if="room !== null">
+                        ({{ room.minGuests }} - {{ room.maxGuests }})
+                    </template>
+                </label>
             </FloatLabel>
             <br />
 

--- a/src/views/room/RoomFind.vue
+++ b/src/views/room/RoomFind.vue
@@ -4,6 +4,7 @@ import { RoomAPI, type PaginatedResultInfoDTO, type QueryRoomsDTO, type RoomResu
 import type { AxiosError, AxiosResponse } from 'axios';
 import type { PageState } from 'primevue';
 import { label } from '@primeuix/themes/aura/metergroup';
+import { RoomImageURL } from '../../api/util';
 
 const rooms = ref<RoomResultDTO[]>([]);
 const info = ref<PaginatedResultInfoDTO | null>(null);
@@ -65,7 +66,7 @@ const resetHours = () => {
 
 const calculateNights = () => {
     nights.value = formDateTo.value.getTime() - formDateFrom.value.getTime();
-    nights.value = nights.value / (1000*3600*24);
+    nights.value = nights.value / (1000 * 3600 * 24);
     nights.value += 1;
 }
 
@@ -79,28 +80,29 @@ onMounted(() => findAvailableRooms());
         <form @submit.prevent="findAvailableRooms" class="left-panel">
             <FloatLabel>
                 <label for="fromDate">From</label>
-                <DatePicker id="fromDate" v-model="formDateFrom"
-                    v-on:value-change="onFromDateChanged" date-format="dd MM" showIcon :style="{ width: '100%' }"/>
+                <DatePicker id="fromDate" v-model="formDateFrom" v-on:value-change="onFromDateChanged"
+                    date-format="dd MM" showIcon :style="{ width: '100%' }" />
             </FloatLabel>
 
             <FloatLabel>
                 <label for="toDate">To</label>
-                <DatePicker id="toDate" v-model="formDateTo" :min-date="new Date(formDateFrom)"
-                    date-format="dd MM" showIcon :style="{ width: '100%' }"/>
+                <DatePicker id="toDate" v-model="formDateTo" :min-date="new Date(formDateFrom)" date-format="dd MM"
+                    showIcon :style="{ width: '100%' }" />
             </FloatLabel>
 
             <FloatLabel>
                 <label>Guests</label>
-                <InputNumber :min="1" v-model.trim="formGuests" fluid placeholder="Add number of guests..."/>
-            </FloatLabel>
-            
-            <FloatLabel>
-                <label>Address</label>
-                <InputText type="text" v-model.trim="formAddress" :maxlength="50" fluid  placeholder="Add address..."/>
+                <InputNumber :min="1" v-model.trim="formGuests" fluid placeholder="Add number of guests..." />
             </FloatLabel>
 
-            <Button type="submit" icon="pi pi-search" label="Search"/>
-            <label>{{ info && info.totalHits ? (info.totalHits > 1 ? info.totalHits + " rooms found." : info.totalHits + " room found.") : "No rooms found." }}</label>
+            <FloatLabel>
+                <label>Address</label>
+                <InputText type="text" v-model.trim="formAddress" :maxlength="50" fluid placeholder="Add address..." />
+            </FloatLabel>
+
+            <Button type="submit" icon="pi pi-search" label="Search" />
+            <label>{{ info && info.totalHits ? (info.totalHits > 1 ? info.totalHits + " rooms found." : info.totalHits +
+                " room found.") : "No rooms found." }}</label>
         </form>
 
         <div class="right-panel">
@@ -108,52 +110,59 @@ onMounted(() => findAvailableRooms());
                 <div v-for="room in rooms" :key="room.id">
                     <RouterLink :to="`/room/${room.id}`" style="text-decoration: none;">
                         <Card style="width: 14rem; overflow: hidden;" :to="`/room/${room.id}`">
-                        <template #header>
-                            <Galleria :value="room.photos" :numVisible="5" :circular="true" :showItemNavigators="true" :showThumbnails="false">
-                                <template #item="photo">
-                                    <img :src="`http://localhost:8505/img/${photo.item}`" :alt="photo.item" style="width: 100%; height: 10rem; object-fit: cover; display: block;" />
-                                </template>
-                            </Galleria>
-                        </template>
-                        <template #title>{{ room.name }}</template>
-                        <template #subtitle>
-                            <div style="font-size: 12pt;">
-                                <p><i class="pi pi-map-marker" style="font-size: 0.7rem"></i> {{ room.address }}</p>
-                            </div>
-                        </template>
-                        <template #content>
-                            <div style="font-size: 11pt;">
-                                <p>{{ room.description.slice(0, 100) }}{{ room.description.length > 100 ? "..." : "" }}</p>
-                            </div>
-                        </template>
-                        <template #footer>
-                            <div style="font-size: 12pt; color: black;">
-                                <p>
-                                    <i class="pi pi-chart-pie" style="font-size: 0.7rem"></i> {{ room.perGuest ? "Per guest rate" : "Flat rate" }}
-                                </p>
-                                <p>
-                                    <i class="pi pi-home" style="font-size: 0.7rem"></i> ${{ room.unitPrice.toFixed(0) }} per night
-                                </p>
-                                <p>
-                                    <i class="pi pi-wallet" style="font-size: 0.7rem"></i> ${{ room.totalPrice }} for {{ nights  == 1 ? "1 night" : nights + " nights"}}
-                                </p>
-                            </div>
-                        </template>
-                    </Card>
+                            <template #header>
+                                <Galleria :value="room.photos" :numVisible="5" :circular="true"
+                                    :showItemNavigators="true" :showThumbnails="false">
+                                    <template #item="photo">
+                                        <img :src="`${RoomImageURL}/img/${photo.item}`" :alt="photo.item"
+                                            style="width: 100%; height: 10rem; object-fit: cover; display: block;" />
+                                    </template>
+                                </Galleria>
+                            </template>
+                            <template #title>{{ room.name }}</template>
+                            <template #subtitle>
+                                <div style="font-size: 12pt;">
+                                    <p><i class="pi pi-map-marker" style="font-size: 0.7rem"></i> {{ room.address }}</p>
+                                </div>
+                            </template>
+                            <template #content>
+                                <div style="font-size: 11pt;">
+                                    <p>{{ room.description.slice(0, 100) }}{{ room.description.length > 100 ? "..." : ""
+                                    }}</p>
+                                </div>
+                            </template>
+                            <template #footer>
+                                <div style="font-size: 12pt; color: black;">
+                                    <p>
+                                        <i class="pi pi-chart-pie" style="font-size: 0.7rem"></i> {{ room.perGuest ?
+                                            "Per guest rate" : "Flat rate" }}
+                                    </p>
+                                    <p>
+                                        <i class="pi pi-home" style="font-size: 0.7rem"></i> ${{
+                                            room.unitPrice.toFixed(0) }} per night
+                                    </p>
+                                    <p>
+                                        <i class="pi pi-wallet" style="font-size: 0.7rem"></i> ${{ room.totalPrice }}
+                                        for {{ nights == 1 ? "1 night" : nights + " nights" }}
+                                    </p>
+                                </div>
+                            </template>
+                        </Card>
                     </RouterLink>
                 </div>
             </div>
 
-            <Paginator :rows="4" :totalRecords="info ? info.totalHits : 0" :rowsPerPageOptions="[4, 16, 48]" @page="onPageChange"></Paginator>
+            <Paginator :rows="4" :totalRecords="info ? info.totalHits : 0" :rowsPerPageOptions="[4, 16, 48]"
+                @page="onPageChange">
+            </Paginator>
         </div>
-    </div>  
+    </div>
 </template>
 
 <style lang="css" scoped>
-
 .p-card {
     --p-card-caption-gap: 0rem;
-}   
+}
 
 .cards {
     display: flex;
@@ -183,6 +192,4 @@ onMounted(() => findAvailableRooms());
     gap: 2rem;
     min-width: 400px;
 }
-
-
 </style>


### PR DESCRIPTION
Closes #36, #26, #37.

---

The number of guests input box is automatically clamped to the room's min and max guests value, closes #36 . There's also a visual indicator of the min and max (see picture below):

<img width="342" height="97" alt="image" src="https://github.com/user-attachments/assets/5a594a59-cb64-4dcc-9e4d-a4cd4b86f8d9" />

The "from" date i.e. reservation start date is limited now, closes #37. See picture below, as dates in the past are disabled:

<img width="365" height="441" alt="image" src="https://github.com/user-attachments/assets/64239961-0390-432d-9903-88bccf08675d" />

Room image URLs are no longer hardcoded using `localhost`, but are fetched from the "dynamic" value of `RoomImageURL` (closes #26)


I cannot reproduce #25 right now, so I may either leave it open or close it.